### PR TITLE
change zeal version to 0.6.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ stage/
 parts/
 *.snap
 *source.tar.bz2
+snap/.snapcraft

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: zeal # you probably want to 'snapcraft register <name>'
-version: '0.4.0' # just for humans, typically '1.2+git' or '1.3.2'
+version: '0.6.1' # just for humans, typically '1.2+git' or '1.3.2'
 summary: Zeal is a simple offline documentation browser inspired by Dash.
 description: |
         Zeal is a simple offline documentation browser inspired by Dash.


### PR DESCRIPTION
- change version to 0.6.1 in snapcraft.yaml
- add snap/.snapcraft to .gitignore

Testing done:
------------------

local docker snapcraft build and manual test on Ubuntu 18.04

```
docker run -v "$PWD":/build -w /build snapcore/snapcraft:stable snapcraft
sudo snap install zeal_0.6.1_amd64.snap --dangerous --devmode
```